### PR TITLE
Implement MySQL GORM event store and switch to Gin

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -10,7 +10,6 @@ import (
 	"demo/internal/infrastructure/eventstore"
 	"demo/internal/infrastructure/messaging"
 	httpiface "demo/internal/interfaces/http"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -34,7 +33,10 @@ func main() {
 	shutdown := initTracer()
 	defer func() { _ = shutdown(context.Background()) }()
 
-	repo := eventstore.NewInMemoryStore()
+	repo, err := eventstore.NewMySQLStore("root@tcp(127.0.0.1:3306)/card_service?parseTime=true")
+	if err != nil {
+		log.Fatal(err)
+	}
 	publisher, err := messaging.NewPublisher([]string{"localhost:9092"})
 	if err != nil {
 		log.Println("failed to create publisher", err)
@@ -45,9 +47,8 @@ func main() {
 	searchHandler := &appquery.SearchCardsHandler{Repo: repo}
 
 	r := httpiface.Router(createHandler, updateHandler, searchHandler)
-	wrapped := otelhttp.NewHandler(r, "card_service")
 	log.Println("http server started on :8080")
-	if err := http.ListenAndServe(":8080", wrapped); err != nil {
+	if err := http.ListenAndServe(":8080", r); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,10 @@ go 1.23.8
 require (
 	github.com/ThreeDotsLabs/watermill v1.4.6
 	github.com/ThreeDotsLabs/watermill-kafka/v2 v2.5.0
-	github.com/go-chi/chi/v5 v5.2.1
+github.com/gin-gonic/gin v1.10.0
+go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.61.0
+gorm.io/driver/mysql v1.5.1
+gorm.io/gorm v1.25.7
 	github.com/google/uuid v1.6.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0
 	go.opentelemetry.io/otel v1.36.0

--- a/internal/infrastructure/eventstore/mysql.go
+++ b/internal/infrastructure/eventstore/mysql.go
@@ -1,0 +1,131 @@
+package eventstore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"demo/internal/domain/card"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+type EventRecord struct {
+	ID      uint   `gorm:"primaryKey"`
+	CardID  string `gorm:"index"`
+	Type    string
+	Payload []byte
+}
+
+type MySQLStore struct {
+	DB *gorm.DB
+}
+
+// NewMySQLStore creates a GORM-based MySQL event store.
+func NewMySQLStore(dsn string) (*MySQLStore, error) {
+	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
+	if err != nil {
+		return nil, err
+	}
+	if err := db.AutoMigrate(&EventRecord{}); err != nil {
+		return nil, err
+	}
+	return &MySQLStore{DB: db}, nil
+}
+
+func eventCardID(evt interface{}) (string, error) {
+	switch e := evt.(type) {
+	case card.CardCreated:
+		return e.ID.String(), nil
+	case card.CardUpdated:
+		return e.ID.String(), nil
+	default:
+		return "", fmt.Errorf("unknown event type %T", evt)
+	}
+}
+
+// Save stores events in MySQL.
+func (s *MySQLStore) Save(ctx context.Context, events []interface{}) error {
+	if len(events) == 0 {
+		return nil
+	}
+	for _, evt := range events {
+		id, err := eventCardID(evt)
+		if err != nil {
+			return err
+		}
+		data, err := json.Marshal(evt)
+		if err != nil {
+			return err
+		}
+		rec := EventRecord{CardID: id, Type: fmt.Sprintf("%T", evt), Payload: data}
+		if err := s.DB.WithContext(ctx).Create(&rec).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Load rebuilds the card state from events.
+func (s *MySQLStore) Load(ctx context.Context, id string) (*card.Card, error) {
+	var records []EventRecord
+	if err := s.DB.WithContext(ctx).Where("card_id = ?", id).Order("id").Find(&records).Error; err != nil {
+		return nil, err
+	}
+	if len(records) == 0 {
+		return nil, nil
+	}
+	c := &card.Card{}
+	for _, r := range records {
+		switch r.Type {
+		case "card.CardCreated":
+			var evt card.CardCreated
+			if err := json.Unmarshal(r.Payload, &evt); err != nil {
+				return nil, err
+			}
+			c.ID = evt.ID
+			c.Name = evt.Name
+			c.Cost = evt.Cost
+			c.Faction = evt.Faction
+			c.Category = evt.Category
+			c.SubCategory = evt.SubCategory
+			c.Description = evt.Description
+		case "card.CardUpdated":
+			var evt card.CardUpdated
+			if err := json.Unmarshal(r.Payload, &evt); err != nil {
+				return nil, err
+			}
+			c.Name = evt.Name
+			c.Cost = evt.Cost
+			c.Faction = evt.Faction
+			c.Category = evt.Category
+			c.SubCategory = evt.SubCategory
+			c.Description = evt.Description
+		}
+	}
+	return c, nil
+}
+
+// Search loads all cards and filters them.
+func (s *MySQLStore) Search(ctx context.Context, name string, cost int, faction, category, sub string) ([]*card.Card, error) {
+	var ids []string
+	if err := s.DB.WithContext(ctx).Model(&EventRecord{}).Distinct("card_id").Find(&ids).Error; err != nil {
+		return nil, err
+	}
+	var cards []*card.Card
+	for _, id := range ids {
+		c, err := s.Load(ctx, id)
+		if err != nil || c == nil {
+			continue
+		}
+		if (name == "" || c.Name == name) &&
+			(cost == 0 || c.Cost == cost) &&
+			(faction == "" || c.Faction == faction) &&
+			(category == "" || c.Category == category) &&
+			(sub == "" || c.SubCategory == sub) {
+			tmp := *c
+			cards = append(cards, &tmp)
+		}
+	}
+	return cards, nil
+}

--- a/tests/mysql_eventstore_test.go
+++ b/tests/mysql_eventstore_test.go
@@ -1,0 +1,43 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"demo/internal/application/command"
+	"demo/internal/application/query"
+	"demo/internal/infrastructure/eventstore"
+)
+
+func TestMySQLCreateAndSearchCard(t *testing.T) {
+	repo, err := eventstore.NewMySQLStore("root@tcp(127.0.0.1:3306)/card_test?parseTime=true")
+	if err != nil {
+		t.Skipf("mysql not available: %v", err)
+	}
+	// clean table
+	_ = repo.DB.Exec("TRUNCATE TABLE event_records")
+
+	handler := &command.CreateCardHandler{Repo: repo}
+	card, err := handler.Handle(context.Background(), command.CreateCardCommand{
+		Name:        "Test",
+		Cost:        1,
+		Faction:     "Human",
+		Category:    "Soldier",
+		SubCategory: "Infantry",
+		Description: "test card",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if card.Name != "Test" {
+		t.Fatalf("expected name Test got %s", card.Name)
+	}
+	queryHandler := &query.SearchCardsHandler{Repo: repo}
+	cards, err := queryHandler.Handle(context.Background(), query.SearchCardsQuery{Name: "Test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cards) != 1 {
+		t.Fatalf("expected 1 card got %d", len(cards))
+	}
+}


### PR DESCRIPTION
## Summary
- add GORM-based MySQL event store
- update HTTP handlers to use Gin
- switch main app to the MySQL store and Gin router
- add integration test for MySQL store

## Testing
- `golangci-lint run ./...` *(fails: could not load packages)*
- `go test ./...` *(fails: missing modules due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6849512bc9a4832c8f2883afdd289320