### PR TITLE
Add unit tests across modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,11 @@ require (
 	gorm.io/gorm v1.25.7
 )
 
+require github.com/yuin/gopher-lua v1.1.1 // indirect
+
 require (
 	github.com/Shopify/sarama v1.38.0 // indirect
+	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/bytedance/sonic v1.13.2 // indirect
 	github.com/bytedance/sonic/loader v0.2.4 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/ThreeDotsLabs/watermill v1.4.6 h1:rWoXlxdBgUyg/bZ3OO0pON+nESVd9r6tnLT
 github.com/ThreeDotsLabs/watermill v1.4.6/go.mod h1:lBnrLbxOjeMRgcJbv+UiZr8Ylz8RkJ4m6i/VN/Nk+to=
 github.com/ThreeDotsLabs/watermill-kafka/v2 v2.5.0 h1:/KYEjLlLx6nW3jn6AEcwAlWkPWP62zi/sUsEP4uKkZE=
 github.com/ThreeDotsLabs/watermill-kafka/v2 v2.5.0/go.mod h1:w+9jhI7x5ZP67ceSUIIpkgLzjAakotfHX4sWyqsKVjs=
+github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
+github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -173,6 +175,8 @@ github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/X
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.0/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.31.0 h1:J8jI81RCB7U9a3qsTZXM/38XrvbLJCye6J32bfQctYY=

--- a/internal/application/command/create_card_test.go
+++ b/internal/application/command/create_card_test.go
@@ -1,0 +1,51 @@
+package command
+
+import (
+	"context"
+	"demo/internal/domain/card"
+	"errors"
+	"testing"
+)
+
+type mockRepo struct {
+	SaveFn   func(ctx context.Context, evts []interface{}) error
+	LoadFn   func(ctx context.Context, id string) (*card.Card, error)
+	SearchFn func(ctx context.Context, name string, cost int, faction, category, sub string) ([]*card.Card, error)
+}
+
+func (m *mockRepo) Save(ctx context.Context, evts []interface{}) error {
+	if m.SaveFn != nil {
+		return m.SaveFn(ctx, evts)
+	}
+	return nil
+}
+func (m *mockRepo) Load(ctx context.Context, id string) (*card.Card, error) {
+	if m.LoadFn != nil {
+		return m.LoadFn(ctx, id)
+	}
+	return nil, nil
+}
+func (m *mockRepo) Search(ctx context.Context, name string, cost int, faction, category, sub string) ([]*card.Card, error) {
+	if m.SearchFn != nil {
+		return m.SearchFn(ctx, name, cost, faction, category, sub)
+	}
+	return nil, nil
+}
+
+func TestCreateCardHandlerError(t *testing.T) {
+	repo := &mockRepo{SaveFn: func(ctx context.Context, evts []interface{}) error { return errors.New("saveerr") }}
+	h := &CreateCardHandler{Repo: repo}
+	_, err := h.Handle(context.Background(), CreateCardCommand{Name: "n"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCreateCardHandlerSuccess(t *testing.T) {
+	repo := &mockRepo{}
+	h := &CreateCardHandler{Repo: repo}
+	c, err := h.Handle(context.Background(), CreateCardCommand{Name: "n"})
+	if err != nil || c == nil || c.Name != "n" {
+		t.Fatalf("unexpected result %v %v", c, err)
+	}
+}

--- a/internal/application/command/update_card_test.go
+++ b/internal/application/command/update_card_test.go
@@ -1,0 +1,31 @@
+package command
+
+import (
+	"context"
+	"demo/internal/domain/card"
+	"errors"
+	"github.com/google/uuid"
+	"testing"
+)
+
+func TestUpdateCardLoadError(t *testing.T) {
+	repo := &mockRepo{}
+	repo.LoadFn = func(ctx context.Context, id string) (*card.Card, error) { return nil, errors.New("load") }
+	h := &UpdateCardHandler{Repo: repo}
+	_, err := h.Handle(context.Background(), UpdateCardCommand{ID: uuid.New()})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestUpdateCardSuccess(t *testing.T) {
+	c := card.NewCard("n", 1, "f", "c", "s", "d")
+	repo := &mockRepo{}
+	repo.LoadFn = func(ctx context.Context, id string) (*card.Card, error) { return c, nil }
+	repo.SaveFn = func(ctx context.Context, evts []interface{}) error { return nil }
+	h := &UpdateCardHandler{Repo: repo}
+	updated, err := h.Handle(context.Background(), UpdateCardCommand{ID: c.ID, Name: "x"})
+	if err != nil || updated == nil {
+		t.Fatalf("unexpected %v %v", updated, err)
+	}
+}

--- a/internal/application/query/search_cards_test.go
+++ b/internal/application/query/search_cards_test.go
@@ -1,0 +1,43 @@
+package query
+
+import (
+	"context"
+	"demo/internal/domain/card"
+	"errors"
+	"testing"
+)
+
+type mockRepo struct {
+	SearchFn func(ctx context.Context, name string, cost int, f, c, s string) ([]*card.Card, error)
+}
+
+func (m *mockRepo) Save(ctx context.Context, evts []interface{}) error      { return nil }
+func (m *mockRepo) Load(ctx context.Context, id string) (*card.Card, error) { return nil, nil }
+func (m *mockRepo) Search(ctx context.Context, name string, cost int, faction, category, sub string) ([]*card.Card, error) {
+	if m.SearchFn != nil {
+		return m.SearchFn(ctx, name, cost, faction, category, sub)
+	}
+	return nil, nil
+}
+
+func TestSearchCardsError(t *testing.T) {
+	repo := &mockRepo{SearchFn: func(ctx context.Context, name string, cost int, f, c, s string) ([]*card.Card, error) {
+		return nil, errors.New("err")
+	}}
+	h := &SearchCardsHandler{Repo: repo}
+	_, err := h.Handle(context.Background(), SearchCardsQuery{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSearchCards(t *testing.T) {
+	repo := &mockRepo{SearchFn: func(ctx context.Context, name string, cost int, f, c, s string) ([]*card.Card, error) {
+		return []*card.Card{{Name: "N"}}, nil
+	}}
+	h := &SearchCardsHandler{Repo: repo}
+	res, err := h.Handle(context.Background(), SearchCardsQuery{})
+	if err != nil || len(res) != 1 {
+		t.Fatalf("unexpected %v %v", res, err)
+	}
+}

--- a/internal/domain/card/card_test.go
+++ b/internal/domain/card/card_test.go
@@ -1,0 +1,16 @@
+package card
+
+import (
+	"github.com/google/uuid"
+	"testing"
+)
+
+func TestNewCard(t *testing.T) {
+	c := NewCard("Name", 1, "Faction", "Category", "Sub", "Desc")
+	if c.Name != "Name" || c.Cost != 1 || c.Faction != "Faction" || c.Category != "Category" || c.SubCategory != "Sub" || c.Description != "Desc" {
+		t.Fatalf("fields not set correctly: %+v", c)
+	}
+	if c.ID == (uuid.UUID{}) {
+		t.Fatal("id not set")
+	}
+}

--- a/internal/i18n/translator_test.go
+++ b/internal/i18n/translator_test.go
@@ -1,0 +1,39 @@
+package i18n
+
+import (
+	"demo/internal/domain/card"
+	"github.com/google/uuid"
+	"testing"
+)
+
+type dummyCard struct{}
+
+func TestTranslate(t *testing.T) {
+	if Translate("zh", "invalid_id") != "無效的ID" {
+		t.Fatalf("unexpected translation")
+	}
+	if Translate("fr", "invalid_id") != "invalid id" { // fallback to en
+		t.Fatalf("fallback failed")
+	}
+	if Translate("unknown", "missing") != "missing" {
+		t.Fatalf("missing key fallback failed")
+	}
+}
+
+func TestTranslateCardNil(t *testing.T) {
+	if TranslateCard("en", nil) != nil {
+		t.Fatal("expected nil map")
+	}
+}
+
+func TestTranslateCard(t *testing.T) {
+	c := &card.Card{ID: uuid.New(), Name: "N", Cost: 1, Faction: "F", Category: "C", SubCategory: "S", Description: "D"}
+	m := TranslateCard("zh", c)
+	if m["名稱"] != "N" || m["費用"] != 1 {
+		t.Fatalf("unexpected map %#v", m)
+	}
+	list := TranslateCards("zh", []*card.Card{c})
+	if len(list) != 1 || list[0]["名稱"] != "N" {
+		t.Fatalf("unexpected list %#v", list)
+	}
+}

--- a/internal/infrastructure/cache/redis_repo_test.go
+++ b/internal/infrastructure/cache/redis_repo_test.go
@@ -1,0 +1,70 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"demo/internal/domain/card"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+type mockRepo struct {
+	SaveFn func(ctx context.Context, evts []interface{}) error
+	LoadFn func(ctx context.Context, id string) (*card.Card, error)
+}
+
+func (m *mockRepo) Save(ctx context.Context, evts []interface{}) error {
+	if m.SaveFn != nil {
+		return m.SaveFn(ctx, evts)
+	}
+	return nil
+}
+func (m *mockRepo) Load(ctx context.Context, id string) (*card.Card, error) {
+	if m.LoadFn != nil {
+		return m.LoadFn(ctx, id)
+	}
+	return nil, nil
+}
+func (m *mockRepo) Search(ctx context.Context, name string, cost int, faction, category, sub string) ([]*card.Card, error) {
+	return nil, nil
+}
+
+func TestRedisRepoSaveError(t *testing.T) {
+	s := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	repo := &mockRepo{SaveFn: func(ctx context.Context, evts []interface{}) error { return errors.New("fail") }}
+	r := &RedisRepository{Repo: repo, Redis: rdb}
+	err := r.Save(context.Background(), []interface{}{card.CardCreated{ID: uuid.New()}})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRedisRepoLoadCacheMiss(t *testing.T) {
+	s := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	repo := &mockRepo{LoadFn: func(ctx context.Context, id string) (*card.Card, error) { return &card.Card{Name: "N"}, nil }}
+	r := &RedisRepository{Repo: repo, Redis: rdb}
+	c, err := r.Load(context.Background(), "x")
+	if err != nil || c == nil || c.Name != "N" {
+		t.Fatalf("unexpected %v %v", c, err)
+	}
+}
+
+func TestRedisRepoLoadCached(t *testing.T) {
+	s := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	repo := &mockRepo{LoadFn: func(ctx context.Context, id string) (*card.Card, error) { return &card.Card{Name: "N"}, nil }}
+	r := &RedisRepository{Repo: repo, Redis: rdb}
+	// prime cache
+	_ = r.Save(context.Background(), []interface{}{card.CardCreated{ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"), Name: "N"}})
+	// manually set invalid json to ensure it falls back to repo
+	rdb.Set(context.Background(), key("x"), "bad", 0)
+	c, err := r.Load(context.Background(), "x")
+	if err != nil || c == nil || c.Name != "N" {
+		t.Fatalf("unexpected %v %v", c, err)
+	}
+}

--- a/internal/infrastructure/eventstore/memory_test.go
+++ b/internal/infrastructure/eventstore/memory_test.go
@@ -1,0 +1,34 @@
+package eventstore
+
+import (
+	"context"
+	"demo/internal/domain/card"
+	"testing"
+)
+
+func TestInMemorySaveLoad(t *testing.T) {
+	repo := NewInMemoryStore()
+	c := card.NewCard("N", 1, "F", "C", "S", "D")
+	evt := card.CardCreated{ID: c.ID, Name: c.Name, Cost: c.Cost, Faction: c.Faction, Category: c.Category, SubCategory: c.SubCategory, Description: c.Description}
+	if err := repo.Save(context.Background(), []interface{}{evt}); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := repo.Load(context.Background(), c.ID.String())
+	if err != nil || loaded == nil || loaded.Name != "N" {
+		t.Fatalf("load failed: %+v %v", loaded, err)
+	}
+}
+
+func TestInMemoryUnknownEvent(t *testing.T) {
+	repo := NewInMemoryStore()
+	if err := repo.Save(context.Background(), []interface{}{struct{}{}}); err != nil {
+		t.Fatal(err)
+	}
+	cards, err := repo.Search(context.Background(), "", 0, "", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cards) != 0 {
+		t.Fatalf("expected 0 cards got %d", len(cards))
+	}
+}

--- a/internal/infrastructure/eventstore/mysql_test.go
+++ b/internal/infrastructure/eventstore/mysql_test.go
@@ -1,0 +1,19 @@
+package eventstore
+
+import (
+	"demo/internal/domain/card"
+	"github.com/google/uuid"
+	"testing"
+)
+
+func TestEventCardID(t *testing.T) {
+	c := card.CardCreated{ID: uuid.New()}
+	id, err := eventCardID(c)
+	if err != nil || id == "" {
+		t.Fatalf("unexpected result %s %v", id, err)
+	}
+	_, err = eventCardID(struct{}{})
+	if err == nil {
+		t.Fatal("expected error for unknown event")
+	}
+}

--- a/internal/infrastructure/messaging/publisher_test.go
+++ b/internal/infrastructure/messaging/publisher_test.go
@@ -1,0 +1,14 @@
+package messaging
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPublishMarshalError(t *testing.T) {
+	p := &Publisher{}
+	err := p.Publish(context.Background(), "t", map[interface{}]string{1: "x"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/interfaces/http/handlers_test.go
+++ b/internal/interfaces/http/handlers_test.go
@@ -1,0 +1,99 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	appcmd "demo/internal/application/command"
+	appquery "demo/internal/application/query"
+	"demo/internal/domain/card"
+)
+
+type mockRepo struct {
+	SaveFn   func(ctx context.Context, evts []interface{}) error
+	LoadFn   func(ctx context.Context, id string) (*card.Card, error)
+	SearchFn func(ctx context.Context, name string, cost int, faction, category, sub string) ([]*card.Card, error)
+}
+
+func (m *mockRepo) Save(ctx context.Context, evts []interface{}) error {
+	if m.SaveFn != nil {
+		return m.SaveFn(ctx, evts)
+	}
+	return nil
+}
+func (m *mockRepo) Load(ctx context.Context, id string) (*card.Card, error) {
+	if m.LoadFn != nil {
+		return m.LoadFn(ctx, id)
+	}
+	return nil, nil
+}
+func (m *mockRepo) Search(ctx context.Context, name string, cost int, faction, category, sub string) ([]*card.Card, error) {
+	if m.SearchFn != nil {
+		return m.SearchFn(ctx, name, cost, faction, category, sub)
+	}
+	return nil, nil
+}
+
+func TestPostInvalidBody(t *testing.T) {
+	repo := &mockRepo{}
+	r := Router(&appcmd.CreateCardHandler{Repo: repo}, &appcmd.UpdateCardHandler{Repo: repo}, &appquery.SearchCardsHandler{Repo: repo})
+	req := httptest.NewRequest("POST", "/cards", bytes.NewBufferString("{"))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 got %d", w.Code)
+	}
+}
+
+func TestPostRepoError(t *testing.T) {
+	repo := &mockRepo{SaveFn: func(ctx context.Context, evts []interface{}) error { return errors.New("fail") }}
+	r := Router(&appcmd.CreateCardHandler{Repo: repo}, &appcmd.UpdateCardHandler{Repo: repo}, &appquery.SearchCardsHandler{Repo: repo})
+	body := `{"name":"n"}`
+	req := httptest.NewRequest("POST", "/cards", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", w.Code)
+	}
+}
+
+func TestPutInvalidID(t *testing.T) {
+	repo := &mockRepo{}
+	r := Router(&appcmd.CreateCardHandler{Repo: repo}, &appcmd.UpdateCardHandler{Repo: repo}, &appquery.SearchCardsHandler{Repo: repo})
+	req := httptest.NewRequest("PUT", "/cards/bad", bytes.NewBufferString("{}"))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 got %d", w.Code)
+	}
+}
+
+func TestGetRepoError(t *testing.T) {
+	repo := &mockRepo{SearchFn: func(ctx context.Context, name string, cost int, f, c, s string) ([]*card.Card, error) {
+		return nil, errors.New("fail")
+	}}
+	r := Router(&appcmd.CreateCardHandler{Repo: repo}, &appcmd.UpdateCardHandler{Repo: repo}, &appquery.SearchCardsHandler{Repo: repo})
+	req := httptest.NewRequest("GET", "/cards", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 got %d", w.Code)
+	}
+}
+
+func TestGetSuccess(t *testing.T) {
+	repo := &mockRepo{SearchFn: func(ctx context.Context, name string, cost int, f, c, s string) ([]*card.Card, error) {
+		return []*card.Card{{Name: "N"}}, nil
+	}}
+	r := Router(&appcmd.CreateCardHandler{Repo: repo}, &appcmd.UpdateCardHandler{Repo: repo}, &appquery.SearchCardsHandler{Repo: repo})
+	req := httptest.NewRequest("GET", "/cards", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- add missing unit tests for domain, i18n and infrastructure packages
- ensure handlers and application logic have failure case coverage
- include caching logic with miniredis for tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684a570f2f38832ca9af2d86b21ffe13